### PR TITLE
WIP - Add timetamp in the tag

### DIFF
--- a/app/msa/core/armve/structs.py
+++ b/app/msa/core/armve/structs.py
@@ -1,6 +1,7 @@
 struct_tag_header = Struct("tag_header",
                            UBInt8("token"),
                            UBInt8("tipo_tag"),
+                           Bytes("timestamp", 4),
                            UBInt16("size"))
 struct_tag = Struct("tag",
                     Embed(struct_tag_header),

--- a/app/msa/core/armve/structs.py
+++ b/app/msa/core/armve/structs.py
@@ -1,9 +1,9 @@
 struct_tag_header = Struct("tag_header",
                            UBInt8("token"),
                            UBInt8("tipo_tag"),
-                           Bytes("timestamp", 4),
                            UBInt16("size"))
 struct_tag = Struct("tag",
                     Embed(struct_tag_header),
                     Bytes("crc32", 4),
+                    Bytes("timestamp", 4),
                     Bytes("user_data", lambda ctx: ctx.size))


### PR DESCRIPTION
En la computación es regular utilizar un "timestamp" (marca de tiempo), en este caso es posible agregar un "timestamp" a la structura de datos llamada "struct_tag".
El campo "user_data" contiene los datos de la votación en cuestion, es considerado un PII (Personal Identifiable Information) en español información personal identificable, este campo es encriptado con una llave que se genera utilizando el chip del presidente de la mesa.